### PR TITLE
Removal of fs module

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "cli-table": "^0.3.1",
     "colors": "^1.1.2",
     "commander": "^2.9.0",
-    "fs": "0.0.1-security",
     "keypress": "^0.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Heya, just a heads up but the fs package is a spam/placeholder package in npm which doesn't serve any purpose other than being an extra dependency. The fs module is built-in so there is no need to explicitly add it to the dependency list. There's more info on this here: https://www.npmjs.com/package/fs and here: http://status.npmjs.org/incidents/dw8cr1lwxkcr. 😃